### PR TITLE
Scan Page

### DIFF
--- a/app/(auth)/(tabs)/scan.tsx
+++ b/app/(auth)/(tabs)/scan.tsx
@@ -1,12 +1,18 @@
-import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
-import React, {useState} from "react";
+import { View, Text, StyleSheet, TouchableOpacity, SafeAreaView, Image } from "react-native";
+import React, {useRef, useState} from "react";
 import { Colors } from "react-native/Libraries/NewAppScreen";
 import { Stack } from "expo-router";
 import { Camera, useCameraDevice } from "react-native-vision-camera";
+import { Ionicons } from "@expo/vector-icons";
+import CameraView from "@/components/CameraView";
+import ScanResults from "@/components/ScanResults";
 
 const Scan = () => {
   const [cameraVisible, setCameraVisible] = useState(false);
   const device = useCameraDevice('back');
+  const [camera, setCamera] = useState<Camera | null>(null);
+  const [image, setImage] = useState<string | null>(null);
+
 
   const requestCameraPermission = async () => {
     const permission = await Camera.requestCameraPermission();
@@ -17,52 +23,39 @@ const Scan = () => {
     }
   };
 
+  const takePicture = async () => {
+    console.log("Taking picture");
+    if (camera) {
+      const photo = await camera.takePhoto();
+      const photoPath = `file://${photo.path}`;
+      setImage(photoPath);
+    }
+  };
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
-      <View style={styles.container}>
+      <SafeAreaView className="flex-1 bg-white items-center justify-center">
         {!cameraVisible ? (
           <>
-            <TouchableOpacity style={styles.button} onPress={requestCameraPermission}>
-              <Text style={styles.buttonText}>Scan Food Waste</Text>
+            <TouchableOpacity className="bg-blue-500 px-5 py-4 rounded-lg" onPress={requestCameraPermission}>
+              <Text className="text-white">Scan Food Waste</Text>
             </TouchableOpacity>
           </>
         ) : (
           device != null ? (
-            <Camera
-              style={StyleSheet.absoluteFill}
-              device={device}
-              isActive={cameraVisible}
-            />
+
+          !image ? (
+            <CameraView device={device} cameraVisible={cameraVisible} setCamera={setCamera} takePicture={takePicture} setCameraVisible={setCameraVisible} />
           ) : (
-            <Text style={styles.text}>No physical camera detected.</Text>
+            <ScanResults image={image} setImage={setImage}/>
+          )
+          ) : (
+            <Text className="text-black">No physical camera detected.</Text>
           )
         )}
-      </View>
+      </SafeAreaView>
     </>
   );
 };
 
 export default Scan;
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    backgroundColor: Colors.white,
-  },
-  text: {
-    color: Colors.black,
-  },
-  button: {
-    backgroundColor: Colors.primary,
-    paddingVertical: 15,
-    paddingHorizontal: 30,
-    borderRadius: 10,
-  },
-  buttonText: {
-    color: Colors.white,
-    fontSize: 16,
-  },
-});

--- a/app/(auth)/(tabs)/scan.tsx
+++ b/app/(auth)/(tabs)/scan.tsx
@@ -1,14 +1,43 @@
-import { View, Text, StyleSheet } from "react-native";
-import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import React, {useState} from "react";
 import { Colors } from "react-native/Libraries/NewAppScreen";
 import { Stack } from "expo-router";
+import { Camera, useCameraDevice } from "react-native-vision-camera";
 
 const Scan = () => {
+  const [cameraVisible, setCameraVisible] = useState(false);
+  const device = useCameraDevice('back');
+
+  const requestCameraPermission = async () => {
+    const permission = await Camera.requestCameraPermission();
+    if (permission === 'granted') {
+      setCameraVisible(true);
+    } else {
+      alert("Camera permission is required to scan");
+    }
+  };
+
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
       <View style={styles.container}>
-        <Text style={styles.text}>Scan</Text>
+        {!cameraVisible ? (
+          <>
+            <TouchableOpacity style={styles.button} onPress={requestCameraPermission}>
+              <Text style={styles.buttonText}>Scan Food Waste</Text>
+            </TouchableOpacity>
+          </>
+        ) : (
+          device != null ? (
+            <Camera
+              style={StyleSheet.absoluteFill}
+              device={device}
+              isActive={cameraVisible}
+            />
+          ) : (
+            <Text style={styles.text}>No physical camera detected.</Text>
+          )
+        )}
       </View>
     </>
   );
@@ -25,5 +54,15 @@ const styles = StyleSheet.create({
   },
   text: {
     color: Colors.black,
+  },
+  button: {
+    backgroundColor: Colors.primary,
+    paddingVertical: 15,
+    paddingHorizontal: 30,
+    borderRadius: 10,
+  },
+  buttonText: {
+    color: Colors.white,
+    fontSize: 16,
   },
 });

--- a/app/(auth)/(tabs)/scan.tsx
+++ b/app/(auth)/(tabs)/scan.tsx
@@ -1,58 +1,17 @@
 import { View, Text, StyleSheet, TouchableOpacity, SafeAreaView, Image } from "react-native";
 import React, {useRef, useState} from "react";
 import { Colors } from "react-native/Libraries/NewAppScreen";
-import { Stack } from "expo-router";
-import { Camera, useCameraDevice } from "react-native-vision-camera";
-import { Ionicons } from "@expo/vector-icons";
-import CameraView from "@/components/CameraView";
-import ScanResults from "@/components/ScanResults";
+import { Stack, router } from "expo-router";
+
 
 const Scan = () => {
-  const [cameraVisible, setCameraVisible] = useState(false);
-  const device = useCameraDevice('back');
-  const [camera, setCamera] = useState<Camera | null>(null);
-  const [image, setImage] = useState<string | null>(null);
-
-
-  const requestCameraPermission = async () => {
-    const permission = await Camera.requestCameraPermission();
-    if (permission === 'granted') {
-      setCameraVisible(true);
-    } else {
-      alert("Camera permission is required to scan");
-    }
-  };
-
-  const takePicture = async () => {
-    console.log("Taking picture");
-    if (camera) {
-      const photo = await camera.takePhoto();
-      const photoPath = `file://${photo.path}`;
-      setImage(photoPath);
-    }
-  };
   return (
     <>
       <Stack.Screen options={{ headerShown: false }} />
       <SafeAreaView className="flex-1 bg-white items-center justify-center">
-        {!cameraVisible ? (
-          <>
-            <TouchableOpacity className="bg-blue-500 px-5 py-4 rounded-lg" onPress={requestCameraPermission}>
-              <Text className="text-white">Scan Food Waste</Text>
-            </TouchableOpacity>
-          </>
-        ) : (
-          device != null ? (
-
-          !image ? (
-            <CameraView device={device} cameraVisible={cameraVisible} setCamera={setCamera} takePicture={takePicture} setCameraVisible={setCameraVisible} />
-          ) : (
-            <ScanResults image={image} setImage={setImage}/>
-          )
-          ) : (
-            <Text className="text-black">No physical camera detected.</Text>
-          )
-        )}
+        <TouchableOpacity className="bg-blue-500 px-5 py-4 rounded-lg" onPress={()=> {router.push("/(auth)/camera")}}>
+          <Text className="text-white">Scan Food Waste</Text>
+        </TouchableOpacity>
       </SafeAreaView>
     </>
   );

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Stack } from "expo-router";
 export default function Layout() {
   return (

--- a/app/(auth)/camera.tsx
+++ b/app/(auth)/camera.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, SafeAreaView, Alert, ActivityIndicator } from "react-native";
+import { router, Stack } from "expo-router";
+import { Camera, useCameraDevice } from "react-native-vision-camera";
+import CameraView from "@/components/CameraView";
+import ScanResults from "@/components/ScanResults";
+
+const CameraScreen = () => {
+  const [cameraVisible, setCameraVisible] = useState<boolean>(false);
+
+  const [image, setImage] = useState<string | null>(null);
+
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+
+  const [camera, setCamera] = useState<Camera | null>(null);
+  const device = useCameraDevice('back');
+
+  const requestCameraPermission = async () => {
+    try {
+      const permission = await Camera.requestCameraPermission();
+      
+      if (permission === 'granted') {
+        setHasPermission(true);
+        if (device) {
+          setCameraVisible(true);
+        }
+      } else {
+        setHasPermission(false);
+      }
+    } catch (error) {
+      console.error('Camera permission error:', error);
+      setHasPermission(false);
+    }
+  };
+
+  const takePicture = async () => {
+    try {
+      if (!camera) return;
+
+      const photo = await camera.takePhoto();
+      const photoPath = `file://${photo.path}`;
+      setImage(photoPath);
+    } catch (error) {
+      console.error('Take picture error:', error);
+      Alert.alert('Camera Error', 'Failed to take picture');
+    }
+  };
+
+  useEffect(() => {
+    requestCameraPermission();
+  }, []);
+
+  useEffect(() => {
+    if (hasPermission === false || !device) {
+      router.back();
+      Alert.alert(
+        'Camera Unavailable', 
+        'Please ensure camera permissions are granted and a camera is available.',
+        [{ text: 'OK' }]
+      );
+    }
+  }, [hasPermission, device]);
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <SafeAreaView className="flex-1 bg-white items-center justify-center">
+        {hasPermission === null ? (
+          <ActivityIndicator size="large" color="#0000ff" />
+        ) : !image ? (
+          <CameraView
+            device={device}
+            cameraVisible={cameraVisible}
+            setCamera={setCamera}
+            takePicture={takePicture}
+          />
+        ) : (
+          <ScanResults image={image} setImage={setImage} />
+        )}
+      </SafeAreaView>
+    </>
+  );
+};
+
+export default CameraScreen;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Stack, useRouter, useSegments } from "expo-router";
 import { useEffect, useState } from "react";
 import "react-native-reanimated";

--- a/components/CameraView.tsx
+++ b/components/CameraView.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import React from 'react'
+import { Camera } from 'react-native-vision-camera'
+import { Ionicons } from '@expo/vector-icons'
+
+interface CameraViewProps {
+  device: any;
+  cameraVisible: boolean;
+  setCamera: (ref: any) => void;
+  takePicture: () => void;
+  setCameraVisible: (visible: boolean) => void;
+}
+
+const CameraView: React.FC<CameraViewProps> = ({ device, cameraVisible, setCamera, takePicture, setCameraVisible }) => {
+  return (
+    <>
+    <Camera
+        style={StyleSheet.absoluteFill}
+        device={device}
+        isActive={cameraVisible}
+        ref={(ref) => setCamera(ref)}
+        photo={true}
+    />
+
+    <TouchableOpacity className=" p-3 rounded-lg top-10 left-0 absolute" onPress={() => setCameraVisible(false)}>
+        <Ionicons name="chevron-back" size={40} color="white" />
+    </TouchableOpacity>
+
+    <TouchableOpacity className=" p-3 rounded-lg bottom-24 absolute" onPress={takePicture}>
+        <View className="border-4 border-white p-4 rounded-full">
+        <View className="w-12 h-12 rounded-full" />
+        </View>
+    </TouchableOpacity>
+    </>
+  )
+}
+
+export default CameraView

--- a/components/CameraView.tsx
+++ b/components/CameraView.tsx
@@ -2,16 +2,16 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import React from 'react'
 import { Camera } from 'react-native-vision-camera'
 import { Ionicons } from '@expo/vector-icons'
+import { router } from 'expo-router';
 
 interface CameraViewProps {
   device: any;
   cameraVisible: boolean;
   setCamera: (ref: any) => void;
   takePicture: () => void;
-  setCameraVisible: (visible: boolean) => void;
 }
 
-const CameraView: React.FC<CameraViewProps> = ({ device, cameraVisible, setCamera, takePicture, setCameraVisible }) => {
+const CameraView: React.FC<CameraViewProps> = ({ device, cameraVisible, setCamera, takePicture }) => {
   return (
     <>
     <Camera
@@ -22,11 +22,11 @@ const CameraView: React.FC<CameraViewProps> = ({ device, cameraVisible, setCamer
         photo={true}
     />
 
-    <TouchableOpacity className=" p-3 rounded-lg top-10 left-0 absolute" onPress={() => setCameraVisible(false)}>
+    <TouchableOpacity className=" p-3 rounded-lg top-10 left-0 absolute" onPress={() => {router.back()}}>
         <Ionicons name="chevron-back" size={40} color="white" />
     </TouchableOpacity>
 
-    <TouchableOpacity className=" p-3 rounded-lg bottom-24 absolute" onPress={takePicture}>
+    <TouchableOpacity className=" p-3 rounded-lg bottom-12 absolute" onPress={takePicture}>
         <View className="border-4 border-white p-4 rounded-full">
         <View className="w-12 h-12 rounded-full" />
         </View>

--- a/components/ScanResults.tsx
+++ b/components/ScanResults.tsx
@@ -1,6 +1,7 @@
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import React from 'react'
 import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
 
 interface ScanResultsProps {
   image: string | null; 
@@ -18,6 +19,9 @@ const ScanResults: React.FC<ScanResultsProps> = ({ image, setImage }) => {
         {image && <Image source={{ uri: image }} className="w-72 h-72"/>}
         <Text className="text-white text-3xl py-2">This is a water bottle!</Text>
       </View>
+      <TouchableOpacity className="bg-blue-500 px-5 py-4 m-5 rounded-lg" onPress={() => router.back()}>
+        <Text className="text-white">Back to Home</Text>
+      </TouchableOpacity>
     </View>
   )
 }

--- a/components/ScanResults.tsx
+++ b/components/ScanResults.tsx
@@ -1,0 +1,25 @@
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import React from 'react'
+import { Ionicons } from '@expo/vector-icons';
+
+interface ScanResultsProps {
+  image: string | null; 
+  setImage: (image: string | null) => void;
+}
+
+const ScanResults: React.FC<ScanResultsProps> = ({ image, setImage }) => {
+  return (
+    <View className=" flex-1 w-full h-12 items-center justify-center">
+       <TouchableOpacity className=" p-3 rounded-lg top-10 left-0 absolute" onPress={() => setImage(null)}>
+        <Ionicons name="chevron-back" size={40} color="black" />
+      </TouchableOpacity>
+      <View className="bg-gray-500 p-5 rounded-lg items-center">
+        <Text className="text-white text-3xl py-2">Water Bottle</Text>
+        {image && <Image source={{ uri: image }} className="w-72 h-72"/>}
+        <Text className="text-white text-3xl py-2">This is a water bottle!</Text>
+      </View>
+    </View>
+  )
+}
+
+export default ScanResults

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-native-reanimated": "~3.10.1",
         "react-native-safe-area-context": "^4.10.5",
         "react-native-screens": "3.31.1",
+        "react-native-vision-camera": "^4.6.1",
         "react-native-web": "~0.19.10",
         "tailwindcss": "^3.4.14"
       },
@@ -18656,6 +18657,30 @@
       "peerDependencies": {
         "react-native": ">=0.59.0",
         "react-native-svg": ">=12.0.0"
+      }
+    },
+    "node_modules/react-native-vision-camera": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-4.6.1.tgz",
+      "integrity": "sha512-USp7g+Q/H7nzIS2XBJTWVdzZArxgZu+IFafgswVzxdmr0iSpLjLUtoUp+SUWxZ+nLhJriYYvqg8hfZrJtnpnlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@shopify/react-native-skia": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": "*",
+        "react-native-worklets-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "@shopify/react-native-skia": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        },
+        "react-native-worklets-core": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
-    "@react-native-async-storage/async-storage": "1.23.1",
     "@firebase/firestore": "^4.7.4",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-firebase/app": "^21.4.0",
     "@react-native-firebase/auth": "^20.5.0",
     "@react-native-firebase/firestore": "^21.4.0",
@@ -45,6 +45,7 @@
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "^4.10.5",
     "react-native-screens": "3.31.1",
+    "react-native-vision-camera": "^4.6.1",
     "react-native-web": "~0.19.10",
     "tailwindcss": "^3.4.14"
   },


### PR DESCRIPTION
# Summary
Implemented 3 screens on the scan tab. The first contains a button, which when pressed, takes the user to a camera view. When they take a picture within this camera view, they are met with a results screen containing the image they just captured. 

# Additional Information
![scan1](https://github.com/user-attachments/assets/253dc7b7-cae0-4a44-8619-5cbdac9a4b4f)
![scan2](https://github.com/user-attachments/assets/ba3c26a1-2db4-4a70-b4a6-938492caa342)
![scan3](https://github.com/user-attachments/assets/9d68d9b4-cacf-413a-923f-b7b7f3c5b478)

Currently works on Android sim, but has not been tested on IOS sim. 

Closes #15 